### PR TITLE
Adds config.json to gitignore template

### DIFF
--- a/src/assets/templates.js
+++ b/src/assets/templates.js
@@ -8,6 +8,7 @@ logs
 .env
 package-lock.json
 {{uuid}}.plugin/backend
+{{uuid}}.plugin/config.json
 `;
 
 // 模板：package.json


### PR DESCRIPTION
Includes the config.json file in the generated gitignore template to prevent accidental sharing of access tokens or other stored settings from development